### PR TITLE
fix: Add root level error boundary

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import { ErrorBoundary as EB } from "react-error-boundary";
+import useBrowser from "../hooks/useBrowser";
+
+type ErrorFallbackProps = {
+  error: Error;
+  resetErrorBoundary: () => void;
+};
+
+export function ErrorFallback({
+  error,
+  resetErrorBoundary,
+}: ErrorFallbackProps) {
+  const browser = useBrowser();
+  return (
+    <div
+      className="m-auto flex flex-col justify-center rounded-xl bg-slate-500 p-10 align-middle shadow-lg lg:max-w-[50%]"
+      role="alert"
+    >
+      <p className="text-center text-[64px]">😧</p>
+      <p className="flex flex-col text-center text-lg">
+        {browser === "Brave" ? (
+          <>
+            <span className="pb-2">
+              Something went wrong and it looks like you&apos;re using Brave.
+            </span>
+            <span className="text-md">
+              This is probably because you have <em>strict</em> fingerprinting
+              enabled.
+            </span>
+          </>
+        ) : (
+          <>
+            <span>Something went wrong!</span>
+            <pre className="pb-2">{error.message}</pre>
+            <button className="" onClick={resetErrorBoundary}>
+              Try again?
+            </button>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}
+
+const errorLogger = (error: Error, info: { componentStack: string }) =>
+  console.error(error, info);
+
+const ErrorBoundary: React.FC = ({ children }) => {
+  return (
+    <EB FallbackComponent={ErrorFallback} onError={errorLogger}>
+      {children}
+    </EB>
+  );
+};
+
+export default ErrorBoundary;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Sky from "./Sky";
 
 import styles from "../styles/Layout.module.css";
+import ErrorBoundary from "./ErrorBoundary";
 
 const currentYear = new Date().getFullYear();
 
@@ -27,29 +28,32 @@ const Layout: React.FC = ({ children }) => {
   const [extraLinksEnabled, _] = useState(
     process.env.NODE_ENV !== "production"
   );
+
   return (
     <div className={styles.container}>
-      <Sky />
+      <ErrorBoundary>
+        <Sky />
 
-      <main className={styles.main}>{children}</main>
+        <main className={styles.main}>{children}</main>
 
-      <footer className="bottom-0 mt-auto flex h-24 w-full flex-col items-center justify-center">
-        <div className="flex">
-          <ActivePath path="/" title="Home." />
-          <ActivePath path="/contact" title="Contact." />
-          {extraLinksEnabled && (
-            <>
-              <ActivePath path="/resume" title="Résumé." />
-              <ActivePath path="/about" title="About." />
-            </>
-          )}
-        </div>
-        <div className="my-2">
-          <p className="text-sm italic">
-            <span>&copy; {currentYear}. All rights reserved.</span>
-          </p>
-        </div>
-      </footer>
+        <footer className="bottom-0 mt-auto flex h-24 w-full flex-col items-center justify-center">
+          <div className="flex">
+            <ActivePath path="/" title="Home." />
+            <ActivePath path="/contact" title="Contact." />
+            {extraLinksEnabled && (
+              <>
+                <ActivePath path="/resume" title="Résumé." />
+                <ActivePath path="/about" title="About." />
+              </>
+            )}
+          </div>
+          <div className="my-2">
+            <p className="text-sm italic">
+              <span>&copy; {currentYear}. All rights reserved.</span>
+            </p>
+          </div>
+        </footer>
+      </ErrorBoundary>
     </div>
   );
 };

--- a/components/Sky.tsx
+++ b/components/Sky.tsx
@@ -15,6 +15,8 @@ export default function Sky() {
 
   return (
     // Ensure DOM is loaded before calculating dpr
+    // This will throw an error in Brave because its fingerprinting prevention logic blocks WebGL context from loading. There is no known workaround ATM.
+    // See: https://github.com/mrdoob/three.js/issues/16904#issuecomment-556386278
     hasMounted && (
       <Canvas camera={cameraSettings} dpr={window.devicePixelRatio}>
         <BackgroundScene />

--- a/hooks/useBrowser.ts
+++ b/hooks/useBrowser.ts
@@ -1,0 +1,7 @@
+import { getBrowser } from "../utils/utils";
+import useIsMounted from "./useIsMounted";
+
+export default function useBrowser() {
+  const isMounted = useIsMounted();
+  return isMounted ? getBrowser() : null;
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-error-boundary": "^3.1.4",
     "three": "^0.138.3",
     "yup": "^0.32.11"
   },

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function FourOhFour() {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center text-center">
       <h1 className="text-4xl">This page does not exist.</h1>
       <span className="mt-2 text-sm italic">(and it probably never will)</span>
       <Link href="/">

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,7 +1,0 @@
-import { NextApiRequest, NextApiResponse } from "next";
-
-const hello = (_: NextApiRequest, res: NextApiResponse) => {
-  res.status(200).json({ text: "Hello" });
-};
-
-export default hello;

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -59,3 +59,44 @@ export function stepColor(color) {
   });
   return color.setHSL(h + 0.00015, s, l);
 }
+
+type Browser =
+  | "Opera"
+  | "Chrome"
+  | "Brave"
+  | "Safari"
+  | "Firefox"
+  | "IE"
+  | "Edge"
+  | "Unknown";
+/**
+ * Gets the name of the browser from the navigators userAgent
+ */
+export function getBrowser(): Browser {
+  const userAgent = navigator.userAgent;
+  const match = userAgent.match(/(chrome|opera|safari|firefox|msie)/i) ?? [];
+  switch (match[1]) {
+    case "Chrome":
+      // @ts-expect-error TypeScript doesn't support browser specific fields, such as this one.
+      //See: https://github.com/microsoft/TypeScript/issues/41532
+      if (navigator.brave?.isBrave().then((res: boolean) => res)) {
+        return "Brave";
+      }
+      if (userAgent.includes("Edge")) {
+        return "Edge";
+      }
+      return "Chrome";
+    case "msie":
+      return "IE";
+    case "Opera":
+    case "Safari":
+    case "Firefox":
+      return match[1] as Browser;
+    default:
+      return "Unknown";
+  }
+}
+
+export function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,6 +38,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@chevrotain/cst-dts-gen@^10.1.2":
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.1.2.tgz#4ee6eff237bb47f4990cfb76c18ee2e71237929c"
@@ -2103,6 +2110,13 @@ react-dom@17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"


### PR DESCRIPTION
Conditionally check if browser is Brave and show a message about webgl rendering problems caused by strict fingerprinting protection.